### PR TITLE
Update New-ITGBackup.ps1

### DIFF
--- a/New-ITGBackup.ps1
+++ b/New-ITGBackup.ps1
@@ -132,6 +132,6 @@ foreach ($FlexibleAsset in $FlexibleAssets.attributes) {
     $outputfilename = $outputfilename.Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
 
     write-host "Ouputting $outputpath\$outputfilename" -ForegroundColor Yellow
-    $HTMLTables | out-file "$outputpath\$($outputfilename).html" -Force
-    $FlexibleAsset.traits | export-csv -path "$outputpath\$($outputfilename).csv" -Force -NoTypeInformation
+    $HTMLTables | out-file -LiteralPath "$outputpath\$($outputfilename).html" -Force
+    $FlexibleAsset.traits | export-csv -LiteralPath "$outputpath\$($outputfilename).csv" -Force -NoTypeInformation
 }


### PR DESCRIPTION
If flexible assets have left/right brackets ( [ ] ) they're interpreted as wildcard paths and would error. Adding -LiteralPath instead solves this.